### PR TITLE
skip karma dependencies by default and provide a `gulp wks-install-karma...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-workspace",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "PoliteJS Workspace Utility Package for GulpJS",
   "main": "index.js",
   "peerDependencies": {
@@ -20,20 +20,7 @@
     "gulp-util": "^3.0.1",
     "webpack": "^1.4.8",
     "jshint-stylish": "^1.0.0",
-    "uglify-js": "^2.4.15",
-    "karma": "^0.12.24",
-    "karma-chai": "^0.1.0",
-    "karma-coverage": "^0.2.6",
-    "karma-mocha": "^0.1.9",
-    "karma-osx-reporter": "^0.1.0",
-    "karma-phantomjs-launcher": "^0.1.4",
-    "karma-sinon": "^1.0.3",
-    "karma-webpack": "^1.3.1",
-    "istanbul": "^0.3.2",
-    "istanbul-instrumenter-loader": "^0.1.2",
-    "mocha": "^2.0.1",
-    "chai": "^1.9.2",
-    "sinon": "^1.10.3"
+    "uglify-js": "^2.4.15"
   },
   "dependencies": {
     "express": "^4.10.0",

--- a/tasks/server.js
+++ b/tasks/server.js
@@ -30,6 +30,29 @@ exports.start = function(gulp, config) {
 	    }
 	});
 
+	gulp.task('wks-install-karma', function(done) {
+		var cmd = 'npm install ' + [
+			"karma@^0.12.24",
+		    "karma-chai@^0.1.0",
+		    "karma-coverage@^0.2.6",
+		    "karma-mocha@^0.1.9",
+		    "karma-osx-reporter@^0.1.0",
+		    "karma-phantomjs-launcher@^0.1.4",
+		    "karma-sinon@^1.0.3",
+		    "karma-webpack@^1.3.1",
+		    "istanbul@^0.3.2",
+		    "istanbul-instrumenter-loader@^0.1.2",
+		    "mocha@^2.0.1",
+		    "chai@^1.9.2",
+		    "sinon@^1.10.3"
+		].join(' ');
+		var watch = childProcess.exec(cmd, function() {});
+	    watch.stdout.on('data', function(data) {
+	        console.log(data);
+	    });
+	    watch.on('exit', done);
+	});
+
 };
 
 function startServer(done) {


### PR DESCRIPTION
...` that install on demand.

closes #1
